### PR TITLE
🧹 Add missing eBPF map logic warning to EBPFBridge

### DIFF
--- a/src/app/core/ebpf_bridge.py
+++ b/src/app/core/ebpf_bridge.py
@@ -50,6 +50,7 @@ class EBPFBridge:
         if _IS_LINUX:
             # TODO: replace with actual BPF map write, e.g.:
             #   bpf["allowed_hashes"][pid] = expected_hash.encode()
+            logger.warning("Missing eBPF map logic for pin_allowed_execution")
             logger.debug(
                 "EBPFBridge.pin_allowed_execution [stub] pid=%s domain=%s hash=%s",
                 pid,


### PR DESCRIPTION
🎯 What: Added a `logger.warning` call to the Linux stub implementation of `EBPFBridge.pin_allowed_execution` in `src/app/core/ebpf_bridge.py`.
💡 Why: Replaces a silent stub with explicit logging indicating that the eBPF map write logic is currently missing/not implemented, which improves maintainability by alerting developers/operators of the missing logic when running on Linux.
✅ Verification: Tested syntax validity using `py_compile`. Verified using manual inspection (`cat`).
✨ Result: `pin_allowed_execution` now logs a warning when invoked on Linux until the actual eBPF map implementation is added.

---
*PR created automatically by Jules for task [10227203381010109528](https://jules.google.com/task/10227203381010109528) started by @IAmSoThirsty*