### PR TITLE
🧹 [Code Health] Fix TODO pattern matching logic

### DIFF
--- a/src/app/miniature_office/repair_crew.py
+++ b/src/app/miniature_office/repair_crew.py
@@ -54,7 +54,7 @@ _BARE_EXCEPT = re.compile(r"^\s*except\s*:\s*$", re.MULTILINE)
 _HARDCODED_SECRET = re.compile(
     r'(?i)\b(password|secret|passwd|api_key|token|auth_key)\s*=\s*["\'][^"\']{3,}["\']'
 )
-_TODO = re.compile(r"#\s*TODO\b", re.IGNORECASE)
+_TODO = re.compile(r"#.*\bTODO\b", re.IGNORECASE)
 
 
 def _scan_file(fpath: Path) -> list[Issue]:


### PR DESCRIPTION
🎯 What: Updated the regular expression `_TODO` to `r\"#.*\\bTODO\\b\"`.
💡 Why: The previous regex (`r\"#\\s*TODO\\b\"`) only matched TODOs if they appeared immediately after the comment hash. The new regex correctly identifies TODOs anywhere within a comment string, improving issue detection reliability.
✅ Verification: Ran `PYTHONPATH=src pytest tests/test_repair_crew.py` to ensure unit tests passed without regressions.
✨ Result: The RepairCrew diagnostics logic is now more robust and accurately surfaces technical debt markers in the codebase.

---
*PR created automatically by Jules for task [12648956665019360878](https://jules.google.com/task/12648956665019360878) started by @IAmSoThirsty*